### PR TITLE
Accept the empty array as a single argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function zipmapObj(objs) {
  */
 module.exports = function zipmap(keys, vals) {
   if (!vals) {
+    if (Array.isArray(keys) && !keys.length) return {};
     if (Array.isArray(keys[0])) return zipmapPairs(keys);
     if (isObj(keys[0])) return zipmapObj(keys);
     throw new TypeError('Expected vals to be an array');

--- a/test.js
+++ b/test.js
@@ -50,6 +50,10 @@ describe('zipmap', function() {
     assert.deepEqual(map, out);
   });
 
+  it('returns an empty object if empty array supplied', function() {
+    assert.deepEqual(zipmap([]), {});
+  });
+
   it('throws a TypeError if not pairs or objs and only supply 1 arg', function() {
     var err;
     try {


### PR DESCRIPTION
``` js
> zipmap([{ key: 'foo', value: 'bar' }].filter(function (item) {
    return item.key == 'foo';
  }))
{ foo: 'bar' }
> zipmap([{ key: 'foo', value: 'bar' }].filter(function (item) {
    return item.key == 'fo';
  }))
TypeError: Expected vals to be an array
```
